### PR TITLE
Add billing frequency and method enumerations

### DIFF
--- a/src/Enums/Billing/Frequencies.php
+++ b/src/Enums/Billing/Frequencies.php
@@ -15,4 +15,11 @@ enum Frequencies: string
      * Represents a billing that occurs only once.
      */
     case ONE_TIME = "ONE_TIME";
+
+    /**
+     * Multiple payments billing.
+     *
+    * Represents a billing that can be paid more than once.
+     */
+    case MULTIPLE_PAYMENTS = "MULTIPLE_PAYMENTS";
 }

--- a/src/Enums/Billing/Methods.php
+++ b/src/Enums/Billing/Methods.php
@@ -15,4 +15,5 @@ enum Methods: string
      * Represents the PIX payment method, a popular instant payment system in Brazil.
      */
     case PIX = "PIX";
+    case CARD = "CARD";
 }

--- a/src/Enums/Billing/Methods.php
+++ b/src/Enums/Billing/Methods.php
@@ -15,5 +15,11 @@ enum Methods: string
      * Represents the PIX payment method, a popular instant payment system in Brazil.
      */
     case PIX = "PIX";
+
+    /**
+     * CARD payment method.
+     *
+     * Represents the card payment method, which includes credit and debit card transactions.
+     */
     case CARD = "CARD";
 }


### PR DESCRIPTION
<!-- We appreciate this, thanks! -->
## Summary
Adds missing billing enumerations to support additional payment scenarios. The `CARD` payment method was added to the payment method enums, and the `MULTIPLE_PAYMENTS` option was added to billing frequency.

## Related Issue

Closes (N/A)

## Why
The library was missing support for some billing configurations already available in the API. Specifically:
- The `CARD` payment method was not present in the payment method enums.
- The `MULTIPLE_PAYMENTS` option was missing from the billing frequency enum.

These additions ensure the enums fully reflect the supported API options.

## What changed
- Added `CARD` to the payment method enum.
- Added `MULTIPLE_PAYMENTS` to the billing frequency enum.
- Updated enum definitions to align with the API capabilities.

## Breaking changes
- [ ] Yes
- [x] No

## Checklist
- [x] Docs updated
- [x] CI passing
- [x] I followed the CONTRIBUTING guidelines
- [x] I added or updated tests (if applicable)

## Additional context

These changes ensure that the library enums stay consistent with the API's supported billing options.